### PR TITLE
Updated Management Interface Header

### DIFF
--- a/src/list/manage/components/app.js
+++ b/src/list/manage/components/app.js
@@ -25,12 +25,11 @@ export default class App extends React.Component {
         <DocumentTitle title="lOCKWISe eNTRIEs">
           <div className={styles.app}>
             <SyncNotification isPanel={false}/>
-            <AppHeader />
+            <AppHeader inputRef={(element) => {
+              this._filterField = element;
+            }}/>
               <section className={styles.appMain}>
-                <AllItems className={styles.aside}
-                          inputRef={(element) => {
-                            this._filterField = element;
-                          }}/>
+                <AllItems className={styles.aside} />
                 <article>
                   <CurrentSelection/>
                 </article>

--- a/src/list/manage/components/item-list-panel.js
+++ b/src/list/manage/components/item-list-panel.js
@@ -7,10 +7,8 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { PanelHeader, PanelBody } from "../../../widgets/panel";
-import AddItem from "../containers/add-item";
 import ItemList, { ItemListPlaceholder } from "../../components/item-list";
 import NoMatchingPlaceholder from "../../containers/no-matching-placeholder";
-import ItemFilter from "../../containers/item-filter";
 import ListSort from "../containers/list-sort.js";
 import ListCounter from "../components/list-counter.js";
 
@@ -45,11 +43,6 @@ export default function ItemListPanel({className, inputRef, totalItemCount,
       <PanelHeader className={styles.panelHeader}
                    border={hasItems ? "floating" : "none"}
                    toolbarClassName={styles.filterToolbar}>
-        <div className={styles.firstRow}>
-          <ItemFilter className={styles.itemFilter}
-                      inputRef={inputRef}/>
-          <AddItem/>
-        </div>
         <div className={styles.secondRow}>
           <ListSort sort={sort} {...props} />
           <div className={styles.flexSpacer}></div>

--- a/src/list/manage/containers/add-item.css
+++ b/src/list/manage/containers/add-item.css
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.add-item {
-  min-width: initial;
-  width: 32px;
-}
+ .add-item {
+     margin: 0 1.5em;
+ }

--- a/src/list/manage/containers/add-item.js
+++ b/src/list/manage/containers/add-item.js
@@ -13,14 +13,11 @@ import { startNewItem } from "../../actions";
 import styles from "./add-item.css";
 
 function AddItem({disabled, onAddItem}) {
-  const imgSrc = browser.extension.getURL("/icons/add-icon.svg");
   return (
-    <Localized id="add-item-button" attrs={{
-      "title": true,
-    }}>
-      <Button theme="primary" title="nEW eNTRy" id="addItemButton" className={styles.addItem} disabled={disabled}
+    <Localized id="add-item-button">
+      <Button theme="normal" size="wide" id="addItemButton" className={styles.addItem} disabled={disabled}
               onClick={onAddItem}>
-        <img src={imgSrc} />
+        nEw lOGIn
       </Button>
     </Localized>
   );

--- a/src/list/manage/containers/app-header.css
+++ b/src/list/manage/containers/app-header.css
@@ -1,22 +1,21 @@
 .app-header {
-  height: 55px;
-  flex-direction: row;
-  background-color: #ededf0;
+  display: flex;
+  height: 75px;
+  flex-flow: row nowrap;
+  align-items: center;
+  background-color: #ffffff;
   border-bottom: 1px solid #d7d7db;
-  position: relative;
 }
+
 .app-header-title {
-  line-height: 55px;
+  flex: 0 0 auto;
+  line-height: 75px;
   margin: 0;
-  padding: 0;
+  padding: 0 5em 0 3em;
   font-size: 22px;
   font-weight: 300;
   letter-spacing: -0.2px;
   text-align: center;
-  color: var(--charcoal-grey);
-  position: absolute;
-  top: 0;
-  left: 44%;
 }
 .app-header-title img {
   height: 1.45em;
@@ -25,17 +24,22 @@
 .app-header-title b {
   font-weight: 600;
 }
+
+.app-header-search {
+  display: flex;
+  flex-flow: row nowrap;
+  flex: 1 1 auto;
+}
+
 .app-header-profile-status {
-  position: absolute;
-  top: 0;
-  right: 0;
+  flex: 0 0 auto;
 }
 .app-header-profile-status button {
   padding: 0 20px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: 55px;
+  height: 75px;
   border: none;
   background: transparent;
   cursor: pointer;

--- a/src/list/manage/containers/app-header.js
+++ b/src/list/manage/containers/app-header.js
@@ -13,14 +13,18 @@ import {
   openSyncPrefs,
   openProfileMenu,
 } from "../../actions";
+import AddItem from "../containers/add-item";
+import ItemFilter from "../../containers/item-filter";
 
 import styles from "./app-header.css";
 
 export class AppHeader extends React.Component {
   static get propTypes() {
     return {
+      store: PropTypes.object,
       profile: PropTypes.object,
       hasProfile: PropTypes.bool.isRequired,
+      inputRef: PropTypes.func,
       onClickMenuFeedback: PropTypes.func.isRequired,
       onClickMenuFAQ: PropTypes.func.isRequired,
       onClickMenuConnect: PropTypes.func.isRequired,
@@ -93,8 +97,10 @@ export class AppHeader extends React.Component {
 
   render() {
     const {
+      store,
       profile,
       hasProfile,
+      inputRef,
       onClickMenuFeedback,
       onClickMenuFAQ,
       onClickMenuConnect,
@@ -113,6 +119,11 @@ export class AppHeader extends React.Component {
           </Localized>
         </h1>
 
+        <div className={styles.appHeaderSearch}>
+          <ItemFilter inputRef={inputRef} store={store}/>
+          <AddItem store={store}/>
+        </div>
+
         <nav className={styles.appHeaderProfileStatus}>
           <button
             id="avatar"
@@ -122,7 +133,7 @@ export class AppHeader extends React.Component {
             {hasProfile ? (
               <React.Fragment>
                 <span data-profile-id={profile.id}>{profile.displayName || profile.email}</span>
-                <img src={profile.avatar} />
+                <img src={profile.avatar} title={profile.displayName || profile.email}/>
               </React.Fragment>
             ) : (
               <img id="logged-out-avatar" src="/images/logged-out-avatar.png" />

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -75,13 +75,12 @@ item-summary-copy-password = Copy Password
   .title = Copy the password to the clipboard
 
 item-filter =
-  .placeholder = Search { -product-short-name }
-  .aria-label = Search { -product-short-name }
+  .placeholder = Search Logins
+  .aria-label = Search Logins
 
 ## manage
 
-add-item-button =
-  .title = New login
+add-item-button = New Login
 
 send-feedback-button = Provide Feedback
 

--- a/test/unit/list/manage/components/item-list-panel-test.js
+++ b/test/unit/list/manage/components/item-list-panel-test.js
@@ -12,7 +12,6 @@ import thunk from "redux-thunk";
 import { initialState, filledState } from "../mock-redux-state";
 import mountWithL10n from "test/unit/mocks/l10n";
 import ItemSummary from "src/list/components/item-summary";
-import ItemFilter from "src/list/containers/item-filter";
 import ItemListPanel from
        "src/list/manage/components/item-list-panel";
 import ListCounter from "src/list/manage/components/list-counter";
@@ -37,7 +36,6 @@ describe("list > manage > components > <ItemListPanel/>", () => {
     });
 
     it("render panel", () => {
-      expect(wrapper).to.have.descendants(ItemFilter);
       expect(wrapper).to.have.descendants(ListCounter);
       expect(wrapper).to.have.descendants(ListSort);
       expect(wrapper.find(ItemSummary)).to.have.length(0);
@@ -61,7 +59,6 @@ describe("list > manage > components > <ItemListPanel/>", () => {
     });
 
     it("render panel", () => {
-      expect(wrapper).to.have.descendants(ItemFilter);
       expect(wrapper).to.have.descendants(ListCounter);
       expect(wrapper).to.have.descendants(ListSort);
       expect(wrapper.find(ItemSummary)).to.have.length(3);

--- a/test/unit/list/manage/containers/app-header-test.js
+++ b/test/unit/list/manage/containers/app-header-test.js
@@ -2,12 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
+import chaiEnzyme from "chai-enzyme";
 import sinon from "sinon";
 import React from "react";
 import mountWithL10n from "test/unit/mocks/l10n";
+import configureStore from "redux-mock-store";
+import { initialState, filledState } from "../mock-redux-state";
+import "test/unit/mocks/browser";
+
+chai.use(chaiEnzyme());
+
+const middlewares = [];
+const mockStore = configureStore(middlewares);
 
 import { AppHeader } from "src/list/manage/containers/app-header";
+import ItemFilter from "src/list/containers/item-filter";
 
 describe("list > manage > containers > <AppHeader/>", () => {
   let mockHandlers, mockDocument, listeners;
@@ -55,11 +65,16 @@ describe("list > manage > containers > <AppHeader/>", () => {
     beforeEach(() => {
       mockProps = {
         ...mockHandlers,
+        store: mockStore(initialState),
         document: mockDocument,
         hasProfile: false,
         profile: null,
       };
       subject = makeSubject(mockProps);
+    });
+
+    it("contains search bar", () => {
+      expect(subject).to.have.descendants(ItemFilter);
     });
 
     it("displays an empty avatar", () => {
@@ -108,6 +123,7 @@ describe("list > manage > containers > <AppHeader/>", () => {
     beforeEach(() => {
       mockProps = {
         ...mockHandlers,
+        store: mockStore(filledState),
         document: mockDocument,
         selectedTab: "logins",
         hasProfile: true,


### PR DESCRIPTION
Fixes #210

Updates the management interface's header bar to match the designs:

* Shift fulll logo to left
* Display search in header
* Display "New Login" button in header, with text instead of "+"
* Background color is White instead of Gray 30

**NOTE** the following differences (as decided for initial launch):

* Retain FxA avatar and display name (instead of using elipsis)

Connected to #206

## Testing and Review Notes

This changes the layout of components; all functionality should still behave as it did in previous builds.


## Screenshots or Videos

![image](https://user-images.githubusercontent.com/757401/57322669-4f1fe480-70c1-11e9-954d-3a5b8c2483b9.png)


## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI