### PR TITLE
Fix errors in CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -2,23 +2,23 @@
 # https://help.github.com/articles/about-codeowners/
 
 # test plans are maintained by PI
-/docs/developer/test-plan*  @mozilla-lockbox/product-integrity
+/docs/developer/test-plan*  @mozilla-lockwise/product-integrity
 
 # metrics docs are maintained by Leif
-/docs/metrics.md            @irrationalagent 
+/docs/metrics.md            @irrationalagent
 
 # tests and related config are maintained by engineering
-/test/                      @mozilla-lockbox/desktop-engineering
+/test/                      @mozilla-lockwise/desktop-engineering
 
 # source code and all other docs are maintained by engineering
-/src/                       @mozilla-lockbox/desktop-engineering
-/docs/                      @mozilla-lockbox/desktop-engineering
+/src/                       @mozilla-lockwise/desktop-engineering
+/docs/                      @mozilla-lockwise/desktop-engineering
 
 # release notes are maintained by the product owners
-/docs/release-notes.md      @mozilla-lockbox/product
+/docs/release-notes.md      @mozilla-lockwise/product
 
 # include Flod for l10n string changes
-src/locales/en-US/*.ftl    @flodolo
+/src/locales/en-US/*.ftl    @flodolo
 
 # otherwise, everything is to be reviewed by the desktop team
-*                           @mozilla-lockbox/desktop-engineering
+*                           @mozilla-lockwise/desktop-engineering


### PR DESCRIPTION
At some point, notifications about CODEOWNERS stopped happening.  From some searching, it appears this could be due to the change in the org name.

Unfortunately, the only way to know for certain it's fixed is to make PRs ...