### PR TITLE
Restyle manage page list

### DIFF
--- a/src/list/components/item-summary.css
+++ b/src/list/components/item-summary.css
@@ -58,12 +58,12 @@ li[data-selected] .info {
 
 .title {
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 500;
   color: #0c0c0d;
 }
 
 .subtitle {
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 300;
   color: #737373;
 }

--- a/src/list/components/item-summary.css
+++ b/src/list/components/item-summary.css
@@ -57,13 +57,13 @@ li[data-selected] .info {
 }
 
 .title {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 500;
   color: #0c0c0d;
 }
 
 .subtitle {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 300;
   color: #737373;
 }

--- a/src/list/components/item-summary.js
+++ b/src/list/components/item-summary.js
@@ -37,8 +37,8 @@ export default function ItemSummary({className, id, title, username, panel}) {
         <Localized id={usernameId}>
           <div data-name="subtitle" className={styles.subtitle}>{username || "nO uSERNAMe"}</div>
         </Localized>
-        {!isNew &&
-           <span className={classNames([styles.info, panel ? styles.panel : ""])}></span>
+        {!isNew && panel &&
+           <span className={classNames([styles.info, styles.panel])}></span>
         }
       </div>
     </div>

--- a/src/list/manage/components/app.css
+++ b/src/list/manage/components/app.css
@@ -47,9 +47,10 @@ body > main,
 
 .aside {
   grid-column: 1;
-  min-width: 250px;
+  width: 280px;
   min-height: 0;
   display: flex;
+  flex-grow: 0;
   flex-direction: column;
   border-inline-end: 1px solid #d7d7db;
 }

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -23,7 +23,7 @@
 }
 
 .second-row {
-  font-weight: normal;
+  font-weight: 300;
   display: flex;
   justify-content: space-between;
   margin-inline-start: 0;

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -9,8 +9,9 @@
 
 .panel-header {
   composes: panel-header from "../../../widgets/panel.css";
-  background: #fff;
+  background: #f9f9fa;
   height: auto;
+  padding: 0;
 }
 
 .first-row, .second-row {
@@ -29,8 +30,8 @@
   margin-inline-start: 0;
   line-height: 32px;
   height: 32px;
-  margin-bottom: -12px;
-  margin-top: 8px;
+  margin: 0;
+  padding: 0 10px;
 }
 
 .item-filter {
@@ -46,6 +47,12 @@
 .list-counter {
   flex-grow: 0;
   flex-shrink: 0;
+  font-size: 12px;
+  color: #737373;
+}
+
+.empty {
+  border-top: 1px solid #d7d7db;
 }
 
 .panel-body ul { 

--- a/src/list/manage/components/item-list-panel.js
+++ b/src/list/manage/components/item-list-panel.js
@@ -22,7 +22,7 @@ export default function ItemListPanel({className, inputRef, totalItemCount,
   if (!hasItems) {
     if (!hasAnything) {
       list = (
-        <ItemListPlaceholder>
+        <ItemListPlaceholder className={styles.empty}>
           <Localized id="all-items-get-started-title">
             <h2>gEt sTARTEd</h2>
           </Localized>

--- a/src/list/manage/components/list-sort.css
+++ b/src/list/manage/components/list-sort.css
@@ -15,6 +15,7 @@
   background: url(/icons/arrow-dropdown.svg) right center no-repeat;
   padding-inline-end: 18px;
   border-radius: 0;
+  padding-left: 3px;
 }
 
 .select option {

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -85,8 +85,6 @@ item-filter =
   .placeholder = Search Logins
   .aria-label = Search Logins
 
-## manage
-
 add-item-button = New Login
 
 send-feedback-button = Provide Feedback


### PR DESCRIPTION
I've rebased desktop-ux against master in #223.

Fixes #211.

As a reminder, key items from #211:

-    Adjust width to better match Firefox Preferences width
-    Remove disclosure arrows
-    Updated styling for logins/entries count
-    Updating styling for sorting control

I might have overdone it by setting a fixed width. If we'd instead like a variable / flex width, just with a narrower `flex-basis` than previously, let me know.

## Screenshots or Videos

Compare this list view with what's in [invision](https://mozilla.invisionapp.com/share/EJRHBMEDKF8#/screens):

<img width="340" alt="Screen Shot 2019-05-08 at 5 09 11 PM" src="https://user-images.githubusercontent.com/96396/57416217-1b71b700-71b4-11e9-9ec8-9236e7b321d1.png">

-----

Here's the empty list view. I added a top-border on the empty list placeholder to make it more consistent with the filled case:

<img width="316" alt="Screen Shot 2019-05-08 at 5 08 33 PM" src="https://user-images.githubusercontent.com/96396/57416218-1b71b700-71b4-11e9-870c-f2a6a1f3b15a.png">


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
