### PR TITLE
Correctly send telemetry after deleting an item

### DIFF
--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -205,12 +205,11 @@ export function removeItem(id) {
   return async (dispatch) => {
     const actionId = nextActionId++;
     dispatch(removeItemStarting(actionId, id));
-
     await browser.runtime.sendMessage({
       type: "remove_item",
       id,
     });
-    dispatch(removeItemCompleted(actionId, id));
+    dispatch(removeItemCompleted(actionId, id, true));
   };
 }
 
@@ -226,11 +225,12 @@ function removeItemStarting(actionId, id) {
   };
 }
 
-function removeItemCompleted(actionId, id) {
+function removeItemCompleted(actionId, id, interactive = false) {
   return {
     type: REMOVE_ITEM_COMPLETED,
     actionId,
     id,
+    interactive,
   };
 }
 

--- a/src/list/manage/telemetry.js
+++ b/src/list/manage/telemetry.js
@@ -86,11 +86,11 @@ export default (store) => (next) => (action) => {
       helpers.websiteOpened(action, "itemDetailManager");
       break;
     case actions.REMOVE_ITEM_COMPLETED:
-      if (action.interactive && action.item) {
+      if (action.interactive && action.id) {
         recordEvent({
           method: "itemDelete",
           object: "manager",
-          extra: { itemid: action.item.id },
+          extra: { itemid: action.id },
         });
       }
       break;

--- a/test/unit/list/actions-test.js
+++ b/test/unit/list/actions-test.js
@@ -137,6 +137,7 @@ describe("list > actions", () => {
         id },
       { type: actions.REMOVE_ITEM_COMPLETED,
         actionId: dispatched[0].actionId,
+        interactive: true,
         id },
     ]);
   });
@@ -274,6 +275,7 @@ describe("list > actions", () => {
     expect(store.getActions()).to.deep.equal([
       { type: actions.REMOVE_ITEM_COMPLETED,
         actionId: undefined,
+        interactive: false,
         id },
     ]);
   });

--- a/test/unit/list/manage/telemetry-test.js
+++ b/test/unit/list/manage/telemetry-test.js
@@ -240,7 +240,7 @@ describe("list > manage > telemetryLogger middleware", () => {
     telemetryLogger(store)(next)({
       type: actions.REMOVE_ITEM_COMPLETED,
       interactive: true,
-      item,
+      id: item.id,
     });
     expect(listener).to.have.been.calledWith({
       type: "telemetry_event",

--- a/test/unit/list/message-ports-test.js
+++ b/test/unit/list/message-ports-test.js
@@ -78,6 +78,7 @@ describe("list > message ports", () => {
     expect(store.getActions()).to.deep.equal([{
       type: actions.REMOVE_ITEM_COMPLETED,
       actionId: dispatched[0].actionId,
+      interactive: false,
       id,
     }]);
   });


### PR DESCRIPTION
Fixes #200.

## Testing and Review Notes

Usual telemetry testing steps apply:
- create and delete a login
- visit `about:telemetry#events-tab`, choose 'dynamic' from the dropdown menu at top right
- you should see an `itemDelete` in the list of events

If you want to verify that deletes outside the Lockwise UI do _not_ trigger the telemetry ping, you'll need to:
- create a login in the manage UI
- go to `about:config`
- clear out the contents of the `signon.management.overrideURI` pref
- go to `about:preferences` > Privacy & Security section > click 'Saved Logins' menu item
- delete the login from the built-in modal:

<img width="1132" alt="Screen Shot 2019-05-10 at 2 23 47 PM" src="https://user-images.githubusercontent.com/96396/57557505-3e74a600-732f-11e9-832a-540fdd92fbe1.png">

- then go back to the `about:telemetry#events-tab` screen and verify that the `itemDelete` event was not fired.

## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [x] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
