### PR TITLE
l10n cleanup

### DIFF
--- a/src/icons/localized/LICENSE
+++ b/src/icons/localized/LICENSE
@@ -1,0 +1,5 @@
+Icons in these subdirectories are not MPL licensed, and product names, logos, and brands are property of their respective owners:
+
+Google Play and the Google Play logo are trademarks of Google LLC.
+
+App Store and the App Store logo are trademarks of Apple Inc.

--- a/src/list/manage/components/promote-banner.css
+++ b/src/list/manage/components/promote-banner.css
@@ -21,10 +21,6 @@
   margin: 0;
   margin-right: 15px;
 }
-.promotion .content .title,
-.promotion .content .details {
-  margin: 0 5px;
-}
 
 .promotion .content strong {
   font-weight: 500;

--- a/src/list/manage/components/promote-banner.js
+++ b/src/list/manage/components/promote-banner.js
@@ -14,44 +14,17 @@ import { classNames } from "../../../common";
 
 import styles from "./promote-banner.css";
 
-export function PromotionBanner({title, details, children}) {
+export function LocalizedPromotionBanner({l10nId, children}) {
   return (
     <Banner className={styles.promotion}>
-      <p className={styles.content}>
-        <strong className={styles.title}>{title}</strong>
-        &ndash;
-        <span className={styles.details}>{details}</span>
-      </p>
+      <Localized id={l10nId}
+                 go={ <strong /> }>
+        <p className={styles.content}>tAkE yOUr pAsSwOrDs eVeRyWhErE - dOwNlOaD oUr aPp</p>
+      </Localized>
       {children}
     </Banner>
   );
 }
-
-PromotionBanner.propTypes = {
-  title: PropTypes.string.isRequired,
-  details: PropTypes.string.isRequired,
-  children: PropTypes.oneOfType([
-    PropTypes.shape({
-      type: PropTypes.oneOf([Button]),
-    }),
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.oneOf([Button]),
-      }),
-    ),
-  ]).isRequired,
-};
-
-export function LocalizedPromotionBanner({l10nId, children}) {
-  return (
-    <Localized id={l10nId} attrs={{title: true, details: true}}>
-      <PromotionBanner title="tItLe" details="dEtAiLs">
-        {children}
-      </PromotionBanner>
-    </Localized>
-  );
-}
-
 LocalizedPromotionBanner.propTypes = {
   l10nId: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
@@ -93,7 +66,7 @@ PromoteDeviceBanner.propTypes = {
 
 export function PromoteFxABanner({onAction}) {
   return (
-    <LocalizedPromotionBanner l10nId="banner-promote-fxa" onAction={onAction}>
+    <LocalizedPromotionBanner l10nId="banner-promote-fxa">
       <Localized id="banner-promote-fxa-action-label">
         <Button
           type="button" className={styles.action}

--- a/src/list/manage/components/promote-banner.js
+++ b/src/list/manage/components/promote-banner.js
@@ -18,7 +18,7 @@ export function LocalizedPromotionBanner({l10nId, children}) {
   return (
     <Banner className={styles.promotion}>
       <Localized id={l10nId}
-                 go={ <strong /> }>
+                 bold={ <strong /> }>
         <p className={styles.content}>tAkE yOUr pAsSwOrDs eVeRyWhErE - dOwNlOaD oUr aPp</p>
       </Localized>
       {children}

--- a/src/list/manage/containers/modals.js
+++ b/src/list/manage/containers/modals.js
@@ -77,6 +77,7 @@ export function ConnectDevice({profile, onClose, onDownloadClick, onSyncPrefsCli
       </DialogBox>
     );
   }
+  const completed = <Localized id="connection-complete"><span>(cOmPlEtE)</span></Localized>;
   return (
     <DialogBox {...props}
       buttons={[{name: "Close", theme: "primary", label: "Close"}]}
@@ -91,11 +92,7 @@ export function ConnectDevice({profile, onClose, onDownloadClick, onSyncPrefsCli
       </Localized>
       <ol>
         <li className={classNames([styles.connect, isComplete ? styles.complete : styles.incomplete])}>
-          { isComplete ? (
-            <Localized id="connect-a-firefox-account-complete"><h3>cOnNeCt a fIrEfOx aCcOuNt (cOmPlEtE)</h3></Localized>
-          ) : (
-            <Localized id="connect-a-firefox-account"><h3>cOnNeCt a fIrEfOx aCcOuNt</h3></Localized>
-          )}
+          <Localized id="connect-a-firefox-account"><h3>cOnNeCt a fIrEfOx aCcOuNt { isComplete ? completed : "" }</h3></Localized>
           <Localized id="sync-requires-account"
             signin={<a onClick={() => onSyncPrefsClick("connect-device-step-one")}></a>}>
             <p>tO SyNc yOuR LoGiNs tO AnOtHeR DeViCe, YoU WiLl nEeD To <signin>SiGn iN Or cReAtE A FiReFoX AcCoUnT</signin>.</p>

--- a/src/list/manage/containers/modals.js
+++ b/src/list/manage/containers/modals.js
@@ -103,8 +103,8 @@ export function ConnectDevice({profile, onClose, onDownloadClick, onSyncPrefsCli
             <h3>eNsUrE ThE &ldquo;lOgInS&rdquo;cHeCkBoX Is sElEcTeD In sYnC PrEfErEnCeS</h3>
           </Localized>
           <Localized id="setting-to-allow-sync"
-            openprefs={<a onClick={() => onSyncPrefsClick("connect-device-step-two")}></a>}>
-            <p>iN OrDeR To aLlOw yOuR LoGiNs tO Be sYnCeD To oThEr dEvIcEs, ThIs sEtTiNg mUsT Be cHeCkEd. <openprefs>oPeN SyNc pReFeReNcEs</openprefs></p>
+            go={<a onClick={() => onSyncPrefsClick("connect-device-step-two")}></a>}>
+            <p>iN OrDeR To aLlOw yOuR LoGiNs tO Be sYnCeD To oThEr dEvIcEs, ThIs sEtTiNg mUsT Be cHeCkEd. <go>oPeN SyNc pReFeReNcEs</go></p>
           </Localized>
         </li>
       </ol>

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -202,7 +202,7 @@ connect-a-firefox-account = Connect a { -fxaccount-brand-name }
 connection-complete = (complete)
 sync-requires-account = To sync your logins to another device, you will need to <signin>sign in or create a { -fxlockwise-brand-name }</signin>.
 ensure-logins-checked = Ensure the “Logins” checkbox is selected in { -sync-brand-short-name } preferences
-setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open { -sync-brand-short-name } preferences</openprefs></p>
+setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <go>Open { -sync-brand-short-name } preferences</go>
 
 banner-promote-device = <bold>Take your passwords everywhere</bold> - download our app for iOS or Android:
 

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -11,8 +11,8 @@
 ## - Translated.
 
 -firefox-brand-name = Firefox
--product-short-name = Lockwise
--product-full-name = Firefox Lockwise
+-fxlockwise-brand-short-name = Lockwise
+-fxlockwise-brand-name = Firefox Lockwise
 
 # “Account” can be localized, “Firefox” must be treated as a brand,
 # and kept in English.
@@ -24,7 +24,7 @@
 
 header-logins-button = Logins
 header-app-title =
-  .title = { -product-full-name }
+  .title = { -fxlockwise-brand-name }
 
 profile-menu-account = Account
 profile-menu-sign-in = Sign in to { -sync-brand-short-name }
@@ -33,7 +33,7 @@ profile-menu-faq = FAQ
 profile-menu-feedback = Provide Feedback
 
 document =
-  .title = { -product-full-name }
+  .title = { -fxlockwise-brand-name }
 
 error-notification-sync = Unable to sync logins.
 error-notification-sync-button = Reconnect
@@ -98,7 +98,7 @@ account-summary-account = Account
 account-summary-options = Preferences
 account-summary-signout = Sign Out
 
-intro-page-header-title = { -product-full-name } for Desktop
+intro-page-header-title = { -fxlockwise-brand-name } for Desktop
 intro-page-header-subtitle =
   Welcome to better login management. Our desktop add-on brings many of
   the improvements seen in our mobile apps to your computer, with
@@ -112,18 +112,18 @@ intro-page-main-article-1-copy =
 intro-page-main-article-2-title =
   Quick access to your logins
 intro-page-main-article-2-copy =
-  Click the { -product-short-name } icon from the toolbar in { -firefox-brand-name } to bring up our
+  Click the { -fxlockwise-brand-short-name } icon from the toolbar in { -firefox-brand-name } to bring up our
   doorhanger to access your logins.
 intro-page-main-article-3-title =
   Create new logins manually
 intro-page-main-article-3-copy =
   With the addition of manual logins, you can now store any account
-  you want within { -product-short-name }.
+  you want within { -fxlockwise-brand-short-name }.
 
 intro-page-footer-heading =
   Not seeing your saved logins? Let us help.
 intro-page-footer-copy =
-  { -product-full-name } provides access to the logins you’ve saved to
+  { -fxlockwise-brand-name } provides access to the logins you’ve saved to
   { -firefox-brand-name } on your device. If your logins are stored on another device,
   you can sync your information to this device by signing in to or
   creating a { -fxaccount-brand-name }. <go>Learn More</go>
@@ -157,7 +157,7 @@ sort-by-last-changed = Last Changed
 
 ## String used in pop-up
 
-manage-logins-button = Open { -product-short-name }
+manage-logins-button = Open { -fxlockwise-brand-short-name }
 
 list-detail-button = Open Website
 
@@ -195,12 +195,12 @@ easily-access-logins = Easily gain access to your logins from any device.
 access-on-another-computer = Access on another computer
 simply-sign-in-other-device = Simply sign in to your { -fxaccount-brand-name } on your other device to sync your logins to that computer.
 download-mobile = Download the mobile app
-download-ios-android = { -product-full-name } is available on both iOS and Android. <learnmore>Click here</learnmore> to learn more and to send a link to your phone to download the app.
+download-ios-android = { -fxlockwise-brand-name } is available on both iOS and Android. <learnmore>Click here</learnmore> to learn more and to send a link to your phone to download the app.
 before-access = Before you can access your logins on another device, you will need to connect a { -fxaccount-brand-name }.
 connect-a-firefox-account = Connect a { -fxaccount-brand-name }
 # Displayed next to connect-a-firefox-account string after the user has logged in.
 connection-complete = (complete)
-sync-requires-account = To sync your logins to another device, you will need to <signin>sign in or create a { -product-full-name }</signin>.
+sync-requires-account = To sync your logins to another device, you will need to <signin>sign in or create a { -fxlockwise-brand-name }</signin>.
 ensure-logins-checked = Ensure the “Logins” checkbox is selected in { -sync-brand-short-name } preferences
 setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open { -sync-brand-short-name } preferences</openprefs></p>
 
@@ -215,6 +215,6 @@ banner-promote-device-play-store =
 
 banner-promote-fxa =
   .title = Take your passwords everywhere
-  .details = create a { -fxaccount-brand-name } or Sign In to sync to { -product-short-name } on mobile:
+  .details = create a { -fxaccount-brand-name } or Sign In to sync to { -fxlockwise-brand-short-name } on mobile:
 
 banner-promote-fxa-action-label = Sign In

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -204,17 +204,13 @@ sync-requires-account = To sync your logins to another device, you will need to 
 ensure-logins-checked = Ensure the “Logins” checkbox is selected in { -sync-brand-short-name } preferences
 setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open { -sync-brand-short-name } preferences</openprefs></p>
 
-banner-promote-device =
-  .title = Take your passwords everywhere
-  .details = download our app for iOS or Android:
+banner-promote-device = <go>Take your passwords everywhere</go> - download our app for iOS or Android:
 
 banner-promote-device-app-store =
   .title = Download on the App Store
 banner-promote-device-play-store =
   .title = Get it on Google Play
 
-banner-promote-fxa =
-  .title = Take your passwords everywhere
-  .details = create a { -fxaccount-brand-name } or Sign In to sync to { -fxlockwise-brand-short-name } on mobile:
+banner-promote-fxa = <go>Take your passwords everywhere</go> - create a { -fxaccount-brand-name } or Sign In to sync to { -fxlockwise-brand-short-name } on mobile:
 
 banner-promote-fxa-action-label = Sign In

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -155,7 +155,7 @@ sort-by-last-used = Last Used
 sort-by-last-changed = Last Changed
 
 
-## String used in pop-up
+## Strings used in pop-up
 
 manage-logins-button = Open { -fxlockwise-brand-short-name }
 
@@ -204,13 +204,13 @@ sync-requires-account = To sync your logins to another device, you will need to 
 ensure-logins-checked = Ensure the “Logins” checkbox is selected in { -sync-brand-short-name } preferences
 setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open { -sync-brand-short-name } preferences</openprefs></p>
 
-banner-promote-device = <go>Take your passwords everywhere</go> - download our app for iOS or Android:
+banner-promote-device = <bold>Take your passwords everywhere</bold> - download our app for iOS or Android:
 
 banner-promote-device-app-store =
   .title = Download on the App Store
 banner-promote-device-play-store =
   .title = Get it on Google Play
 
-banner-promote-fxa = <go>Take your passwords everywhere</go> - create a { -fxaccount-brand-name } or Sign In to sync to { -fxlockwise-brand-short-name } on mobile:
+banner-promote-fxa = <bold>Take your passwords everywhere</bold> - create a { -fxaccount-brand-name } or Sign In to sync to { -fxlockwise-brand-short-name } on mobile:
 
 banner-promote-fxa-action-label = Sign In

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -198,8 +198,8 @@ download-mobile = Download the mobile app
 download-ios-android = { -product-full-name } is available on both iOS and Android. <learnmore>Click here</learnmore> to learn more and to send a link to your phone to download the app.
 before-access = Before you can access your logins on another device, you will need to connect a { -fxaccount-brand-name }.
 connect-a-firefox-account = Connect a { -fxaccount-brand-name }
-# Displayed after the connection has completed
-connect-a-firefox-account-complete = Connect a { -fxaccount-brand-name } (complete)
+# Displayed next to connect-a-firefox-account string after the user has logged in.
+connection-complete = (complete)
 sync-requires-account = To sync your logins to another device, you will need to <signin>sign in or create a { -product-full-name }</signin>.
 ensure-logins-checked = Ensure the “Logins” checkbox is selected in { -sync-brand-short-name } preferences
 setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open { -sync-brand-short-name } preferences</openprefs></p>


### PR DESCRIPTION
Fixes #204 (addresses remaining unchecked checkboxes, except for splitting untranslated and translated content, which I think we've handled via comments in list.ftl).

Feedback welcome on the handling of the string in the modal. Infixing the strong tag led to JSX trimming the whitespace on the right side of the tag, so I resorted to including a margin in the strong tag. I can move that into a classname, if desired.

Not sure what's up with the broken unit test; I'll look at that in a bit.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
