### PR TITLE
Strip Path from Website Address on Save

### DIFF
--- a/src/background/datastore.js
+++ b/src/background/datastore.js
@@ -91,6 +91,16 @@ export function convertItem2Info(item) {
   return info;
 }
 
+function extractOrigin(str) {
+  try {
+    const url = new URL(str);
+    return url.origin;
+  } catch (ex) {
+    // ignore failure  -- pretend it'll still save
+    return str;
+  }
+}
+
 class DataStore {
   constructor() {
     this._all = {};
@@ -122,6 +132,8 @@ class DataStore {
     let info = convertItem2Info(item);
     if (!info.hostname) {
       throw new TypeError("missing hostname");
+    } else {
+      info.hostname = extractOrigin(info.hostname);
     }
     if (!info.password) {
       throw new TypeError("missing password");
@@ -133,6 +145,8 @@ class DataStore {
     if (!info.formSubmitURL && !info.httpRealm) {
       // assume formSubmitURL === hostname
       info.formSubmitURL = info.hostname;
+    } else if (info.formSubmitURL) {
+      info.formSubmitURL = extractOrigin(info.formSubmitURL);
     }
 
     let added = {

--- a/src/list/manage/components/edit-item-details.js
+++ b/src/list/manage/components/edit-item-details.js
@@ -66,6 +66,15 @@ export default class EditItemDetails extends React.Component {
     const {itemId, ...saveState} = this.state;
     const newItem = itemId === null;
     const isDuplicate = error && !!~error.message.indexOf("This login already exists");
+    const hostname = ((str) => {
+      try {
+        const url = new URL(str);
+        return url.hostname;
+      } catch (ex) {
+        // ignore error; present the "raw" value
+        return str;
+      }
+    })(this.state.origin);
 
     return (
       <form className={classNames([styles.itemDetails, styles.editing])}
@@ -74,7 +83,7 @@ export default class EditItemDetails extends React.Component {
               e.preventDefault();
               onSave(saveState);
             }}>
-        {isDuplicate && <DuplicateNotification title={(new URL(this.state.origin).hostname)} />}
+        {isDuplicate && <DuplicateNotification title={hostname} />}
         <header className="detail-title">
           {newItem ? (
             <Localized id={`item-details-heading-new`}>

--- a/src/list/manage/components/edit-item-details.js
+++ b/src/list/manage/components/edit-item-details.js
@@ -74,8 +74,8 @@ export default class EditItemDetails extends React.Component {
               e.preventDefault();
               onSave(saveState);
             }}>
+        {isDuplicate && <DuplicateNotification title={(new URL(this.state.origin).hostname)} />}
         <header className="detail-title">
-        {isDuplicate && <DuplicateNotification title={(new URL(this.state.origin).hostname)}/>}
           {newItem ? (
             <Localized id={`item-details-heading-new`}>
               <h1>cREATe nEw eNTRy</h1>

--- a/test/unit/background/datastore-test.js
+++ b/test/unit/background/datastore-test.js
@@ -270,6 +270,32 @@ describe("background > datastore", () => {
     expect(resultApiInfo.timePasswordChanged).to.not.be.undefined;
     expect(resultApiInfo).to.deep.equal(expectedApiInfo);
   });
+  it("allow an item to be added, massaging the hostname", async () => {
+    const info = {
+      title: "QUUX title",
+      hostname: "http://quux.example.com",
+      formSubmitURL: "http://quux.example.com",
+      httpRealm: null,
+      username: "QUUXuser",
+      password: "QUUXpass",
+      usernameField: "username",
+      passwordField: "password",
+      timeLastUsed: Date.now(),
+      timePasswordChanged: Date.now(),
+      timeCreated: Date.now(),
+      timesUsed: 0,
+    };
+    const item = convertInfo2Item(info);
+    info.hostname += "/";
+
+    const addedItem = await store.add(item);
+    const expectedItem = {
+      ...item,
+      id: addedItem.id,
+    };
+
+    expect(addedItem).to.deep.equal(expectedItem);
+  });
 
   it("allows an item to be updated", async () => {
     const id = "BAR";


### PR DESCRIPTION
Fixes #238
Fixes #236

The main patch coerces the `hostname` and `formSubmitURL` into an origin when adding a login.  This helps make manually-saved logins more reliable.

While open to there, corrected the "duplicate entry" error to be it's own row (again).

## Testing and Review Notes

Unit test added to verify behavior.

Perform steps from #238; the expected result should now be the login will work with autofill/autocomplete.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)