### PR TITLE
Correctly send telemetry after clicking the popup footer 'open website' link

### DIFF
--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -442,9 +442,10 @@ export function concealPassword(id) {
   };
 }
 
-export function openWebsite() {
+export function openWebsite(item) {
   return {
     type: OPEN_WEBSITE,
+    item,
   };
 }
 

--- a/src/list/components/item-fields.js
+++ b/src/list/components/item-fields.js
@@ -6,7 +6,6 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { openWebsite } from "../common";
 import CopyToClipboardButton from "../../widgets/copy-to-clipboard-button";
 import FieldText from "../../widgets/field-text";
 import Input from "../../widgets/input";
@@ -25,11 +24,11 @@ const fieldsPropTypes = PropTypes.shape({
   password: PropTypes.string.isRequired,
 });
 
-export function ItemFields({fields, onCopy, isPopup, onReveal}) {
+export function ItemFields({fields, onCopy, isPopup, onReveal, onOpenWebsite}) {
   const originEl = isPopup ? (
       <h4 className={styles.popupOrigin}>{new URL(fields.origin).host}</h4>
   ) : (
-      <a className={styles.originLink} onClick={() => openWebsite(fields.origin)}>{fields.origin}</a>
+      <a className={styles.originLink} onClick={onOpenWebsite}>{fields.origin}</a>
   );
 
   const originLabel = isPopup ? null : (
@@ -40,7 +39,7 @@ export function ItemFields({fields, onCopy, isPopup, onReveal}) {
 
   const launchButton = isPopup ? null : (
       <Button theme="normal" title={"launch"}
-              onClick={() => openWebsite(fields.origin)}>
+              onClick={onOpenWebsite}>
       <Localized id="item-fields-origin-button">
       <span>lAUNCh</span>
       </Localized>
@@ -91,6 +90,7 @@ ItemFields.propTypes = {
   isPopup: PropTypes.bool,
   onCopy: PropTypes.func.isRequired,
   onReveal: PropTypes.func.isRequired,
+  onOpenWebsite: PropTypes.func.isRequired,
 };
 
 export class EditItemFields extends React.Component {

--- a/src/list/manage/components/item-details.js
+++ b/src/list/manage/components/item-details.js
@@ -17,7 +17,7 @@ const dateOptions = {year: "numeric", month: "long", day: "numeric" };
 
 // Note: ItemDetails doesn't directly interact with items from the Lockwise
 // datastore. For that, please consult <../containers/current-item.js>.
-export default function ItemDetails({fields, onCopy, onEdit, onDelete, onReveal}) {
+export default function ItemDetails({fields, onCopy, onEdit, onDelete, onReveal, onOpenWebsite}) {
   const created = new Date(fields.timeCreated).toLocaleDateString(LOCALE, dateOptions);
   const modified = new Date(fields.timePasswordChanged).toLocaleDateString(LOCALE, dateOptions);
   const lastUsed = new Date(fields.timeLastUsed).toLocaleDateString(LOCALE, dateOptions);
@@ -40,7 +40,7 @@ export default function ItemDetails({fields, onCopy, onEdit, onDelete, onReveal}
         </Toolbar>
       </header>
 
-      <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} />
+      <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} onOpenWebsite={onOpenWebsite} />
 
       <div className={styles.metadata}>
         <hr/>

--- a/src/list/manage/containers/current-selection.js
+++ b/src/list/manage/containers/current-selection.js
@@ -10,6 +10,7 @@ import { flattenItem, unflattenItem } from "../../common";
 import {
   addItem, updateItem, requestRemoveItem, editCurrentItem, requestCancelEditing,
   editorChanged, copiedField, revealPassword, concealPassword, openFAQ,
+  openWebsite,
 } from "../../actions";
 import EditItemDetails from "../components/edit-item-details";
 import ItemDetails from "../components/item-details";
@@ -58,6 +59,7 @@ const ConnectedItemDetails = connect(
       dispatch(show ? revealPassword(ownProps.item && ownProps.item.id)
         : concealPassword(ownProps.item && ownProps.item.id));
     },
+    onOpenWebsite: () => { dispatch(openWebsite(ownProps.item)); },
   })
 )(ItemDetails);
 

--- a/src/list/open-link-middleware.js
+++ b/src/list/open-link-middleware.js
@@ -42,6 +42,10 @@ export default (store) => (next) => (action) => {
   case actions.OPEN_PLAY_STORE:
     openWebsite(urls.androidStore, false);
     break;
+  case actions.OPEN_WEBSITE:
+    const url = action.item.origins[0];
+    openWebsite(url, false);
+    break;
   }
   return next(action);
 };

--- a/src/list/popup/components/item-details-panel.js
+++ b/src/list/popup/components/item-details-panel.js
@@ -22,7 +22,7 @@ export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal, onOp
       </Localized>
 
       <PanelBody className={styles.panelBody}>
-        <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} isPopup={true}/>
+        <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} onOpenWebsite={onOpenWebsite} isPopup={true}/>
       </PanelBody>
 
       <PanelFooter border="floating">

--- a/src/list/popup/components/item-details-panel.js
+++ b/src/list/popup/components/item-details-panel.js
@@ -6,14 +6,13 @@ import { Localized } from "fluent-react";
 import React from "react";
 import PropTypes from "prop-types";
 
-import { openWebsite } from "../../common";
 import Panel, { PanelHeader, PanelBody, PanelFooter,
                 PanelFooterButton } from "../../../widgets/panel";
 import { ItemFields } from "../../components/item-fields";
 
 import styles from "./item-details-panel.css";
 
-export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal}) {
+export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal, onOpenWebsite}) {
   return (
     <Panel>
       <Localized id="item-details-panel-title">
@@ -28,7 +27,7 @@ export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal}) {
 
       <PanelFooter border="floating">
         <Localized id="list-detail-button">
-          <PanelFooterButton onClick={() => openWebsite(fields.origin)} className={styles.panelFooterButton}>
+          <PanelFooterButton onClick={onOpenWebsite} className={styles.panelFooterButton}>
             oPEn wEBSITe
           </PanelFooterButton>
         </Localized>
@@ -42,4 +41,5 @@ ItemDetailsPanel.propTypes = {
   onCopy: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
   onReveal: PropTypes.func.isRequired,
+  onOpenWebsite: PropTypes.func.isRequired,
 };

--- a/src/list/popup/containers/current-selection.js
+++ b/src/list/popup/containers/current-selection.js
@@ -7,7 +7,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { flattenItem } from "../../common";
-import { selectItem, copiedField } from "../../actions";
+import { selectItem, copiedField, openWebsite } from "../../actions";
 import AllItemsPanel from "./all-items-panel";
 import ItemDetailsPanel from "../components/item-details-panel";
 import { concealPassword, revealPassword } from "../../actions";
@@ -23,6 +23,7 @@ const ConnectedItemDetailsPanel = connect(
       const id = ownProps.item && ownProps.item.id;
       return dispatch(show ? revealPassword(id) : concealPassword(id));
     },
+    onOpenWebsite: () => { dispatch(openWebsite(ownProps.item)); },
   })
 )(ItemDetailsPanel);
 


### PR DESCRIPTION

Turns out the click handler wasn't wired up via container, but just
called common/openWebsite directly from the component. Updated to pass
the callback in via container, fire an action on click, handle the
telemetry response via the telemetry middleware, and handle actually
opening the website via the open-link middleware.

Fixes #202.

Fixes #???

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

Connected to #???

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
