### PR TITLE
Send correct boolean state in telemetry when nonempty popup is shown

### DIFF
--- a/src/list/popup/telemetry.js
+++ b/src/list/popup/telemetry.js
@@ -15,8 +15,11 @@ export default (store) => (next) => (action) => {
       helpers.itemCopied(action, "itemDetailDoorhanger");
       break;
     case actions.LIST_ITEMS_COMPLETED:
-      const state = store.getState();
-      helpers.listShown(action, "itemListDoorhanger", state.cache.items);
+      // Accessing item info from the store requires waiting a turn.
+      setTimeout(() => {
+        const state = store.getState();
+        helpers.listShown(action, "itemListDoorhanger", state.cache.items);
+      }, 0);
       break;
     case actions.OPEN_WEBSITE:
       helpers.websiteOpened(action, "itemDetailDoorhanger");

--- a/test/unit/list/popup/telemetry-test.js
+++ b/test/unit/list/popup/telemetry-test.js
@@ -65,7 +65,7 @@ describe("list > popup > telemetryLogger middleware", () => {
     itemCopied.restore();
   });
 
-  it("record telemetry for showing a non-empty list of items", () => {
+  it("record telemetry for showing a non-empty list of items", (done) => {
     const listShown = sinon.spy(telemetry, "listShown");
     store.getState = sinon.stub().returns({
       list: {
@@ -79,8 +79,12 @@ describe("list > popup > telemetryLogger middleware", () => {
       type: actions.LIST_ITEMS_COMPLETED,
     };
     telemetryLogger(store)(next)(action);
-    expect(listShown).to.have.been.calledWith(action, "itemListDoorhanger", [item]);
-    listShown.restore();
+    // Wait a turn for the listener to be called.
+    setTimeout(() => {
+      expect(listShown).to.have.been.calledWith(action, "itemListDoorhanger", [item]);
+      listShown.restore();
+      done();
+    }, 0);
   });
 
   it("record telemetry for opening a website", async () => {


### PR DESCRIPTION
Fixes #203.

## Testing and Review Notes

Some of the telemetry middleware action handlers need to `getState()`, but doing so requires waiting a turn via `setTimeout`. I had figured this out in the management page telemetry middleware, but missed this single spot on the popup side where the same trick is needed.

## Screenshots or Videos

See the original bug for solid steps to reproduce and a nice GIF :sparkles:

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding integration tests
- [n/a] request the "UX" team perform a design review (if/when applicable)
- [X] make sure CI builds are passing (e.g.: fix lint and other errors)
- [n/a] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [n/a] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
