### PR TITLE
Correctly fire the 'itemSelected' telemetry event when selecting an item from either list

### DIFF
--- a/src/list/manage/telemetry.js
+++ b/src/list/manage/telemetry.js
@@ -98,8 +98,8 @@ export default (store) => (next) => (action) => {
         helpers.passwordRevealed(action, "itemDetailManager");
       break;
     case actions.SELECT_ITEM_STARTING:
-      if (action.item) {
-        helpers.itemSelected(action, "manager");
+      if (action.id) {
+        helpers.itemSelected(action.id, "manager");
       }
       break;
     case actions.SELECT_ITEM_COMPLETED:

--- a/src/list/popup/telemetry.js
+++ b/src/list/popup/telemetry.js
@@ -30,8 +30,8 @@ export default (store) => (next) => (action) => {
       }
       break;
     case actions.SELECT_ITEM_STARTING:
-      if (action.item) {
-        helpers.itemSelected(action, "doorhanger");
+      if (action.id) {
+        helpers.itemSelected(action.id, "doorhanger");
       }
       break;
     }

--- a/src/list/telemetry.js
+++ b/src/list/telemetry.js
@@ -24,11 +24,11 @@ const itemCopied = (action, object) => {
 };
 
 // object =  'manager' || 'doorhanger'
-const itemSelected = (action, object) => {
+const itemSelected = (itemid, object) => {
   recordEvent({
     method: "itemSelected",
     object,
-    extra: { itemid: action.item.id },
+    extra: { itemid },
   });
 };
 

--- a/test/unit/list/manage/telemetry-test.js
+++ b/test/unit/list/manage/telemetry-test.js
@@ -276,10 +276,10 @@ describe("list > manage > telemetryLogger middleware", () => {
     const itemSelected = sinon.spy(telemetry, "itemSelected");
     const action = {
       type: actions.SELECT_ITEM_STARTING,
-      item,
+      id: item.id,
     };
     telemetryLogger(store)(next)(action);
-    expect(itemSelected).to.have.been.calledWith(action, "manager");
+    expect(itemSelected).to.have.been.calledWith(item.id, "manager");
     itemSelected.restore();
   });
 

--- a/test/unit/list/popup/telemetry-test.js
+++ b/test/unit/list/popup/telemetry-test.js
@@ -109,10 +109,10 @@ describe("list > popup > telemetryLogger middleware", () => {
     const itemSelected = sinon.spy(telemetry, "itemSelected");
     const action = {
       type: actions.SELECT_ITEM_STARTING,
-      item,
+      id: item.id,
     };
     telemetryLogger(store)(next)(action);
-    expect(itemSelected).to.have.been.calledWith(action, "doorhanger");
+    expect(itemSelected).to.have.been.calledWith(item.id, "doorhanger");
     itemSelected.restore();
   });
 

--- a/test/unit/list/telemetry-test.js
+++ b/test/unit/list/telemetry-test.js
@@ -52,11 +52,7 @@ describe("list > shared telemetryLogger middleware", () => {
   });
 
   it("itemSelected", async () => {
-    const action = {
-      type: actions.SELECT_ITEM_STARTING,
-      item,
-    };
-    telemetryLogger.itemSelected(action, "manager");
+    telemetryLogger.itemSelected(item.id, "manager");
     expect(listener).to.have.been.calledWith({
       type: "telemetry_event",
       data: {


### PR DESCRIPTION
Fixes #201.

## Testing and Review Notes

The telemetry code assumed that the `SELECT_ITEM_STARTING` action included an `item` with an `id`, but the action really just has the `id`. Updated the telemetry code and tests accordingly, which fixes the bug.

## Screenshots or Videos

Again, the original bug has good STR.


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding integration tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)