### PR TITLE
Track show/hide password via Redux

### DIFF
--- a/src/list/components/item-fields.js
+++ b/src/list/components/item-fields.js
@@ -24,7 +24,7 @@ const fieldsPropTypes = PropTypes.shape({
   password: PropTypes.string.isRequired,
 });
 
-export function ItemFields({fields, onCopy, isPopup, onReveal, onOpenWebsite}) {
+export function ItemFields({fields, showPassword, onCopy, isPopup, onReveal, onOpenWebsite}) {
   const originEl = isPopup ? (
       <h4 className={styles.popupOrigin}>{new URL(fields.origin).host}</h4>
   ) : (
@@ -74,7 +74,7 @@ export function ItemFields({fields, onCopy, isPopup, onReveal, onOpenWebsite}) {
           <LabelText>pASSWORd</LabelText>
         </Localized>
         <div className={styles.inlineButton}>
-          <PasswordText data-name="password" value={fields.password} onReveal={onReveal} />
+          <PasswordText data-name="password" value={fields.password} showPassword={showPassword} onReveal={onReveal} />
           <Localized id="item-fields-copy-password">
             <CopyToClipboardButton value={fields.password} isPopup={isPopup}
                                    onCopy={toCopy => onCopy("password", toCopy)}/>
@@ -88,6 +88,7 @@ export function ItemFields({fields, onCopy, isPopup, onReveal, onOpenWebsite}) {
 ItemFields.propTypes = {
   fields: fieldsPropTypes,
   isPopup: PropTypes.bool,
+  showPassword: PropTypes.bool,
   onCopy: PropTypes.func.isRequired,
   onReveal: PropTypes.func.isRequired,
   onOpenWebsite: PropTypes.func.isRequired,
@@ -98,6 +99,7 @@ export class EditItemFields extends React.Component {
     return {
       itemId: PropTypes.string,
       fields: fieldsPropTypes.isRequired,
+      showPassword: PropTypes.bool,
       onChange: PropTypes.func.isRequired,
       onReveal: PropTypes.func.isRequired,
     };
@@ -114,7 +116,7 @@ export class EditItemFields extends React.Component {
   }
 
   render() {
-    const {fields, onChange, onReveal} = this.props;
+    const {fields, showPassword, onChange, onReveal} = this.props;
     const controlledProps = (name, maxLength = 500) => {
       return {name, value: fields[name],
               onChange: (e) => onChange(e),
@@ -164,6 +166,7 @@ export class EditItemFields extends React.Component {
           </Localized>
           <PasswordInput className={styles.password}
                          required
+                         showPassword={showPassword}
                          onReveal={onReveal}
                          {...controlledProps("password")}/>
         </label>

--- a/src/list/manage/components/edit-item-details.js
+++ b/src/list/manage/components/edit-item-details.js
@@ -62,7 +62,7 @@ export default class EditItemDetails extends React.Component {
   }
 
   render() {
-    const {fields: { title }, onSave, onCancel, onDelete, onReveal, error} = this.props;
+    const {fields: { title }, showPassword, onSave, onCancel, onDelete, onReveal, error} = this.props;
     const {itemId, ...saveState} = this.state;
     const newItem = itemId === null;
     const isDuplicate = error && !!~error.message.indexOf("This login already exists");
@@ -104,6 +104,7 @@ export default class EditItemDetails extends React.Component {
           )}
         </header>
         <EditItemFields fields={this.state}
+                        showPassword={showPassword}
                         onReveal={onReveal}
                         onChange={(e) => this.handleChange(e)}/>
         <Toolbar className={styles.actions}>

--- a/src/list/manage/components/item-details.js
+++ b/src/list/manage/components/item-details.js
@@ -17,7 +17,7 @@ const dateOptions = {year: "numeric", month: "long", day: "numeric" };
 
 // Note: ItemDetails doesn't directly interact with items from the Lockwise
 // datastore. For that, please consult <../containers/current-item.js>.
-export default function ItemDetails({fields, onCopy, onEdit, onDelete, onReveal, onOpenWebsite}) {
+export default function ItemDetails({fields, showPassword, onCopy, onEdit, onDelete, onReveal, onOpenWebsite}) {
   const created = new Date(fields.timeCreated).toLocaleDateString(LOCALE, dateOptions);
   const modified = new Date(fields.timePasswordChanged).toLocaleDateString(LOCALE, dateOptions);
   const lastUsed = new Date(fields.timeLastUsed).toLocaleDateString(LOCALE, dateOptions);
@@ -40,7 +40,7 @@ export default function ItemDetails({fields, onCopy, onEdit, onDelete, onReveal,
         </Toolbar>
       </header>
 
-      <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} onOpenWebsite={onOpenWebsite} />
+      <ItemFields fields={fields} showPassword={showPassword} onCopy={onCopy} onReveal={onReveal} onOpenWebsite={onOpenWebsite} />
 
       <div className={styles.metadata}>
         <hr/>

--- a/src/list/manage/containers/current-selection.js
+++ b/src/list/manage/containers/current-selection.js
@@ -21,6 +21,7 @@ const ConnectedEditItemDetails = connect(
   (state, ownProps) => ({
     itemId: ownProps.item ? ownProps.item.id : undefined,
     fields: ownProps.item ? flattenItem(ownProps.item) : undefined,
+    showPassword: state.list.showPassword,
   }),
   (dispatch, ownProps) => {
     let onSave;
@@ -50,6 +51,7 @@ const ConnectedEditItemDetails = connect(
 const ConnectedItemDetails = connect(
   (state, ownProps) => ({
     fields: flattenItem(ownProps.item),
+    showPassword: state.list.showPassword,
   }),
   (dispatch, ownProps) => ({
     onCopy: (field, toCopy) => { dispatch(copiedField(field, toCopy, ownProps.item)); },

--- a/src/list/popup/components/item-details-panel.js
+++ b/src/list/popup/components/item-details-panel.js
@@ -12,7 +12,7 @@ import { ItemFields } from "../../components/item-fields";
 
 import styles from "./item-details-panel.css";
 
-export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal, onOpenWebsite}) {
+export default function ItemDetailsPanel({fields, showPassword, onCopy, onBack, onReveal, onOpenWebsite}) {
   return (
     <Panel>
       <Localized id="item-details-panel-title">
@@ -22,7 +22,12 @@ export default function ItemDetailsPanel({fields, onCopy, onBack, onReveal, onOp
       </Localized>
 
       <PanelBody className={styles.panelBody}>
-        <ItemFields fields={fields} onCopy={onCopy} onReveal={onReveal} onOpenWebsite={onOpenWebsite} isPopup={true}/>
+        <ItemFields fields={fields}
+                    showPassword={showPassword}
+                    onCopy={onCopy}
+                    onReveal={onReveal}
+                    onOpenWebsite={onOpenWebsite}
+                    isPopup={true}/>
       </PanelBody>
 
       <PanelFooter border="floating">

--- a/src/list/popup/containers/current-selection.js
+++ b/src/list/popup/containers/current-selection.js
@@ -15,6 +15,7 @@ import { concealPassword, revealPassword } from "../../actions";
 const ConnectedItemDetailsPanel = connect(
   (state, ownProps) => ({
     fields: flattenItem(ownProps.item),
+    showPassword: state.list.showPassword,
   }),
   (dispatch, ownProps) => ({
     onCopy: (field, toCopy) => { dispatch(copiedField(field, toCopy, ownProps.item)); },

--- a/src/list/reducers.js
+++ b/src/list/reducers.js
@@ -95,18 +95,23 @@ export function listReducer(state = {
   switch (action.type) {
   case actions.ADD_ITEM_COMPLETED:
     if (action.interactive) {
-      return {...state, selectedItemId: action.item.id};
+      return {...state, selectedItemId: action.item.id, showPassword: false};
     }
     return state;
   case actions.SELECT_ITEM_STARTING:
-    return {...state, selectedItemId: action.id};
+    return {...state, selectedItemId: action.id, showPassword: false};
   case actions.START_NEW_ITEM:
-    return {...state, selectedItemId: NEW_ITEM_ID};
+    return {...state, selectedItemId: NEW_ITEM_ID, showPassword: false};
   case actions.CANCEL_EDITING:
     if (state.selectedItemId === NEW_ITEM_ID) {
-      return {...state, selectedItemId: null};
+      return {...state, selectedItemId: null, showPassword: false};
     }
-    return state;
+    return {...state, showPassword: false};
+  case actions.EDIT_CURRENT_ITEM:
+  case actions.CONCEAL_PASSWORD:
+    return {...state, showPassword: false};
+  case actions.REVEAL_PASSWORD:
+    return {...state, showPassword: true};
   case actions.FILTER_ITEMS:
     return {...state, filter: {
       query: action.filter,

--- a/src/widgets/password-input.js
+++ b/src/widgets/password-input.js
@@ -17,6 +17,7 @@ export default class PasswordInput extends React.Component {
       className: PropTypes.string,
       monospace: PropTypes.bool,
       disabled: PropTypes.bool,
+      showPassword: PropTypes.bool,
       onReveal: PropTypes.func.isRequired,
     };
   }
@@ -31,17 +32,6 @@ export default class PasswordInput extends React.Component {
 
   constructor(props) {
     super(props);
-
-    this.state = {
-      showPassword: false,
-    };
-    this.showPassword = this.showPassword.bind(this);
-  }
-
-  showPassword(show) {
-    const {onReveal} = this.props;
-    this.setState({showPassword: show});
-    onReveal(show);
   }
 
   focus() {
@@ -49,10 +39,7 @@ export default class PasswordInput extends React.Component {
   }
 
   render() {
-    // onReveal isn't used here, but it needs to be removed from `...props`
-    // eslint-disable-next-line no-unused-vars
-    const {className, monospace, disabled, onReveal, ...props} = this.props;
-    const {showPassword} = this.state;
+    const {className, monospace, disabled, showPassword, onReveal, ...props} = this.props;
     const selectedIndex = showPassword ? 1 : 0;
 
     return (
@@ -67,12 +54,12 @@ export default class PasswordInput extends React.Component {
           <Localized id="password-input-show" attrs={{title: true}}>
             <button type="button" className={styles.showBtn} title="sHOw"
                     disabled={disabled}
-                    onClick={() => this.showPassword(true)}/>
+                    onClick={() => onReveal(true)}/>
           </Localized>
           <Localized id="password-input-hide" attrs={{title: true}}>
             <button type="button" className={styles.hideBtn} title="hIDe"
                     disabled={disabled}
-                    onClick={() => this.showPassword(false)}/>
+                    onClick={() => onReveal(false)}/>
           </Localized>
         </Stack>
       </div>

--- a/src/widgets/password-text.js
+++ b/src/widgets/password-text.js
@@ -17,6 +17,7 @@ export default class PasswordText extends React.Component {
     return {
       className: PropTypes.string,
       value: PropTypes.string,
+      showPassword: PropTypes.bool,
       onReveal: PropTypes.func.isRequired,
     };
   }
@@ -30,23 +31,10 @@ export default class PasswordText extends React.Component {
 
   constructor(props) {
     super(props);
-
-    this.state = {
-      showPassword: false,
-    };
-  }
-
-  showPassword(show) {
-    const {onReveal} = this.props;
-    this.setState({showPassword: show});
-    onReveal(show);
   }
 
   render() {
-    // We don't need onReveal here, but need to exclude it from ...props.
-    // eslint-disable-next-line no-unused-vars
-    const {className, value, onReveal, ...props} = this.props;
-    const {showPassword} = this.state;
+    const {className, value, showPassword, onReveal, ...props} = this.props;
 
     return (
       <div {...props} className={classNames([
@@ -59,7 +47,7 @@ export default class PasswordText extends React.Component {
             {value}
             <Localized id="password-input-hide" attrs={{title: true}}>
               <button type="button" className={styles.hideBtn} title="hIDe"
-                      onClick={() => this.showPassword(false)}/>
+                      onClick={() => onReveal(false)}/>
             </Localized>
           </span>
         ) : (
@@ -67,7 +55,7 @@ export default class PasswordText extends React.Component {
             {PASSWORD_DOT.repeat(value.length)}
             <Localized id="password-input-show" attrs={{title: true}}>
               <button type="button" className={styles.showBtn} title="sHOw"
-                      onClick={() => this.showPassword(true)}/>
+                      onClick={() => onReveal(true)}/>
             </Localized>
           </span>
         )}

--- a/test/unit/list/reducers-test.js
+++ b/test/unit/list/reducers-test.js
@@ -390,6 +390,7 @@ describe("list > reducers", () => {
 
         expect(listReducer(undefined, action)).to.deep.equal({
           selectedItemId: "1",
+          showPassword: false,
           filter: {
             query: "",
             userEntered: true,
@@ -426,6 +427,7 @@ describe("list > reducers", () => {
 
       expect(listReducer(undefined, action)).to.deep.equal({
         selectedItemId: "1",
+        showPassword: false,
         filter: {
           query: "",
           userEntered: true,
@@ -440,6 +442,7 @@ describe("list > reducers", () => {
 
       expect(listReducer(undefined, action)).to.deep.equal({
         selectedItemId: NEW_ITEM_ID,
+        showPassword: false,
         filter: {
           query: "",
           userEntered: true,
@@ -462,6 +465,7 @@ describe("list > reducers", () => {
 
         expect(listReducer(state, action)).to.deep.equal({
           selectedItemId: null,
+          showPassword: false,
           filter: {
             query: "",
             userEntered: true,
@@ -483,6 +487,7 @@ describe("list > reducers", () => {
 
         expect(listReducer(state, action)).to.deep.equal({
           selectedItemId: "1",
+          showPassword: false,
           filter: {
             query: "",
             userEntered: true,

--- a/test/unit/widgets/password-input-test.js
+++ b/test/unit/widgets/password-input-test.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import chai, { expect } from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
 import chaiEnzyme from "chai-enzyme";
 import React from "react";
 
@@ -12,6 +14,7 @@ import PasswordInput from "src/widgets/password-input";
 
 chai.use(chaiEnzyme());
 chai.use(chaiFocus);
+chai.use(sinonChai);
 
 describe("widgets > <PasswordInput/>", () => {
   it("render input", () => {
@@ -19,6 +22,21 @@ describe("widgets > <PasswordInput/>", () => {
       <PasswordInput value="my password" onReveal={() => {}} onChange={() => {}}/>
     );
     expect(wrapper.find("input")).to.have.prop("value", "my password");
+    expect(wrapper.find("input")).to.have.prop("type", "password");
+    expect(wrapper.childAt(0).prop("className")).to.match(
+      /^\S+password\S+ \S+input-wrapper\S+$/
+    );
+    expect(wrapper.find("input").prop("className")).to.match(
+      /^\S+monospace\S+$/
+    );
+  });
+
+  it("render showing password", () => {
+    const wrapper = mountWithL10n(
+      <PasswordInput value="my password" showPassword={true} onReveal={() => { }} onChange={() => { }} />
+    );
+    expect(wrapper.find("input")).to.have.prop("value", "my password");
+    expect(wrapper.find("input")).to.have.prop("type", "text");
     expect(wrapper.childAt(0).prop("className")).to.match(
       /^\S+password\S+ \S+input-wrapper\S+$/
     );
@@ -43,17 +61,24 @@ describe("widgets > <PasswordInput/>", () => {
     expect(wrapper.find("input")).to.have.prop("className", "");
   });
 
-  it("show/hide button toggles password visibility", async () => {
+  it("show button triggers callback", async () => {
+    const spy = sinon.spy();
     const wrapper = mountWithL10n(
-      <PasswordInput value="password" onReveal={() => {}} onChange={() => {}}/>
+      <PasswordInput value="password" showPassword={false} onReveal={spy} onChange={() => {}}/>
     );
-    expect(wrapper.find("input")).to.have.prop("type", "password");
 
     wrapper.find("button").at(0).simulate("click");
-    expect(wrapper.find("input")).to.have.prop("type", "text");
+    expect(spy).to.have.been.calledWith(true);
+  });
+
+  it("hide button triggers callback", async () => {
+    const spy = sinon.spy();
+    const wrapper = mountWithL10n(
+      <PasswordInput value="password" showPassword={true} onReveal={spy} onChange={() => { }} />
+    );
 
     wrapper.find("button").at(1).simulate("click");
-    expect(wrapper.find("input")).to.have.prop("type", "password");
+    expect(spy).to.have.been.calledWith(false);
   });
 
   it("focus() focuses input", () => {


### PR DESCRIPTION
Fixes #253

Tracks the showing and hiding of the password field using Redux instead of an internal React property.  This also aggressively "disables" showing the password on various state changes within a view, to minimize the exposure of the password.

## Testing and Review Notes

Unit tests have been updated to confirm state changes are tracked, and the password fields are hidden/shown via property.

For manual testing, follow the steps to reproduce from #253; the password field is now hidden when selecting a new item to display.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
