### PR TITLE
Add notes on localization preparation steps

### DIFF
--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -19,13 +19,15 @@ Before a release can be made, the following must be done:
 
 To merge the strings from localization:
 
-1. Update the `master` branch with the latest commits from the `pontoon` branch with a git merge and/or Pull Request.
+1. Update the `master` branch with the latest commits from the `pontoon` branch with a Pull Request.
 
   * This way the translations from the Pontoon service are made available to the release.
+  * https://github.com/mozilla-lockwise/lockwise-addon/compare/pontoon?expand=1
 
-2. Update the `pontoon` branch with the latest commits from the `master` branch with a git merge and/or Pull Request
+2. Update the `pontoon` branch with the latest commits from the `master` branch with a Pull Request.
 
-  * This way the Pontoon service will only expose stable strings to translators
+  * This way the Pontoon service will only expose stable strings to translators.
+  * https://github.com/mozilla-lockwise/lockwise-addon/compare/pontoon...master?expand=1
 
 To generate the next release binary:
 

--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -17,6 +17,16 @@ Before a release can be made, the following must be done:
 * You are an administrator of the project `lockbox-addon`
 * Your local git working copy has a remote named `upstream` pointing to `git@github.com:mozilla-lockbox/lockbox-addon.git`
 
+To merge the strings from localization:
+
+1. Update the `master` branch with the latest commits from the `pontoon` branch with a git merge and/or Pull Request.
+
+  * This way the translations from the Pontoon service are made available to the release.
+
+2. Update the `pontoon` branch with the latest commits from the `master` branch with a git merge and/or Pull Request
+
+  * This way the Pontoon service will only expose stable strings to translators
+
 To generate the next release binary:
 
 1. Update "version" in package.json (and package-lock.json)

--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -23,8 +23,10 @@ To merge the strings from localization:
 
   * This way the translations from the Pontoon service are made available to the release.
   * https://github.com/mozilla-lockwise/lockwise-addon/compare/pontoon?expand=1
+  
+2. Check the [`locales.json` file](https://github.com/mozilla-lockwise/lockwise-addon/tree/master/src/locales) includes all the locales expected to be made available to users (and add it, if not).
 
-2. Update the `pontoon` branch with the latest commits from the `master` branch with a Pull Request.
+3. Update the `pontoon` branch with the latest commits from the `master` branch with a Pull Request.
 
   * This way the Pontoon service will only expose stable strings to translators.
   * https://github.com/mozilla-lockwise/lockwise-addon/compare/pontoon...master?expand=1


### PR DESCRIPTION
Based on the fact Pontoon is hooked up to the `pontoon` branch now, we want to make sure we incorporate these steps to make sure translations get incorporated into the product.