### PR TITLE
Run `OpenSyncPrefs` Through Redux Dispatcher

### DIFF
--- a/src/list/containers/connected-sync-notification.js
+++ b/src/list/containers/connected-sync-notification.js
@@ -13,6 +13,6 @@ export default connect(({
   hasProfileNeedsAttn,
 }),
   dispatch => ({
-    reconnectToSync: () => openSyncPrefs(),
+    reconnectToSync: () => dispatch(openSyncPrefs()),
   })
 )(SyncNotification);


### PR DESCRIPTION
Fixes #263

This PR ensures the `openSyncPrefs()` action is dispatched through Redux.

## Testing and Review Notes

Follow steps in #152

## Screenshots or Videos

_TBD_


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)