### PR TITLE
Allow for Varying Widths of the Doorhanger

### DIFF
--- a/src/list/popup/components/app.css
+++ b/src/list/popup/components/app.css
@@ -5,13 +5,19 @@
 body {
   padding: 0;
   margin: 0;
-  min-width: 300px;
+  width: 100%;
   height: 339px;
   color: #0c0c0d;
   background-color: #ffffff;
   font: caption;
   font-size: 13px;
   -moz-user-select: none;
+}
+
+@media (max-width: 300px) {
+  body {
+    width: 300px;
+  }
 }
 
 body > main,

--- a/src/list/popup/components/app.css
+++ b/src/list/popup/components/app.css
@@ -5,7 +5,7 @@
 body {
   padding: 0;
   margin: 0;
-  width: 300px;
+  min-width: 300px;
   height: 339px;
   color: #0c0c0d;
   background-color: #ffffff;


### PR DESCRIPTION
Fixes #152

This changes the doorhanger from a fixed width to using CSS media queries to fix the width to 300px if the viewport is no bigger than that, or 100% if larger.

## Testing and Review Notes

1. Either pin the Lockwise toolbar to the overflow menu, or narrow the main browser window until Lockwise is moved into an overflow menu
2. Click the overflow menu chevron, then Lockwise

## Screenshots or Videos

**Doorhanger in overflow:**
![addon-152 doorhanger-overflow](https://user-images.githubusercontent.com/757401/58271681-d28c3780-7d49-11e9-93da-9771987ee425.gif)

**Doorhanger in toolbar:**
![addon-152 doorhanger-toolbar](https://user-images.githubusercontent.com/757401/58271685-d6b85500-7d49-11e9-8625-a1b54904b86c.gif)

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)