### PR TITLE
Disable failing integration/functional tests

### DIFF
--- a/test/integration/functional-test.js
+++ b/test/integration/functional-test.js
@@ -61,7 +61,7 @@ const mockLogin = {
 
 const WAIT_DELAY = 1000;
 
-describe("add-on UI", () => {
+describe.skip("add-on UI", () => {
   let webext, driver, helper, webdriver, By, until, selectors;
 
   const waitFor = by => driver.wait(until.elementLocated(by), WAIT_DELAY);


### PR DESCRIPTION
The functional tests are constantly failing in odd ways.  Given the lifetime of this project and that manual QA has done more to find fuzzy issues than our automated tests, disabling the set.

No, this is not ideal – far from it.  However, these haven't been increasing quality, so their value is increasingly questionable.