### PR TITLE
Ensure doorhanger closes when Launching a Website

### DIFF
--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -442,10 +442,11 @@ export function concealPassword(id) {
   };
 }
 
-export function openWebsite(item) {
+export function openWebsite(item, close) {
   return {
     type: OPEN_WEBSITE,
     item,
+    close,
   };
 }
 

--- a/src/list/open-link-middleware.js
+++ b/src/list/open-link-middleware.js
@@ -44,7 +44,7 @@ export default (store) => (next) => (action) => {
     break;
   case actions.OPEN_WEBSITE:
     const url = action.item.origins[0];
-    openWebsite(url, actions.close);
+    openWebsite(url, action.close);
     break;
   }
   return next(action);

--- a/src/list/open-link-middleware.js
+++ b/src/list/open-link-middleware.js
@@ -44,7 +44,7 @@ export default (store) => (next) => (action) => {
     break;
   case actions.OPEN_WEBSITE:
     const url = action.item.origins[0];
-    openWebsite(url, false);
+    openWebsite(url, actions.close);
     break;
   }
   return next(action);

--- a/src/list/popup/containers/current-selection.js
+++ b/src/list/popup/containers/current-selection.js
@@ -24,7 +24,7 @@ const ConnectedItemDetailsPanel = connect(
       const id = ownProps.item && ownProps.item.id;
       return dispatch(show ? revealPassword(id) : concealPassword(id));
     },
-    onOpenWebsite: () => { dispatch(openWebsite(ownProps.item)); },
+    onOpenWebsite: () => { dispatch(openWebsite(ownProps.item, true)); },
   })
 )(ItemDetailsPanel);
 


### PR DESCRIPTION
Fixes #266

This change adds a `close` flag to the `openWebsite` action, which will close the popup if set to true.

## Testing and Review Notes

Follow the steps in #266

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon