### PR TITLE
Tidy up README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status][travisci-image]][travisci-link]
+[![CircleCI][circleci-image]][circleci-link]
 [![codecov][codecov-image]][codecov-link]
 
 # Firefox Lockbox for Desktop
@@ -29,8 +29,8 @@ version 2.0][license-link].
 
 Note that some test fixtures use source code from third-party services, and are not subject to this license.
 
-[travisci-image]: https://travis-ci.org/mozilla-lockwise/lockwise-addon.svg?branch=master
-[travisci-link]: https://travis-ci.org/mozilla-lockwise/lockwise-addon
+[circleci-image]: https://circleci.com/gh/mozilla-lockwise/lockwise-addon.svg?style=svg
+[circleci-link]: https://circleci.com/gh/mozilla-lockwise/lockwise-addon
 [codecov-image]: https://codecov.io/gh/mozilla-lockwise/lockwise-addon/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/mozilla-lockwise/lockwise-addon
 [docs-link]: docs/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status][travisci-image]][travisci-link]
 [![codecov][codecov-image]][codecov-link]
-[![Waffle Board][waffle-image]][waffle-link]
 
 # Firefox Lockbox for Desktop
 
@@ -34,8 +33,6 @@ Note that some test fixtures use source code from third-party services, and are 
 [travisci-link]: https://travis-ci.org/mozilla-lockwise/lockwise-addon
 [codecov-image]: https://codecov.io/gh/mozilla-lockwise/lockwise-addon/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/mozilla-lockwise/lockwise-addon
-[waffle-image]: https://badge.waffle.io/mozilla-lockwise/lockwise-extension.svg?columns=In%20Progress
-[waffle-link]: https://waffle.io/mozilla-lockwise/lockwise-extension
 [docs-link]: docs/
 [org-website]: https://lockwise.firefox.com/
 [contributing-link]: docs/contributing.md


### PR DESCRIPTION
- Removes Waffle board link that no longer exists
- Switches to Circle CI since that's what we use now