### PR TITLE
Improve Visuals to Better Account for Welsh Localization

### DIFF
--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -46,7 +46,7 @@
 }
 
 .list-counter {
-  flex: 1 1 auto;
+  flex: 1 0 auto;
   font-size: 12px;
   color: #4a4a4f;
   text-align: right;

--- a/src/list/manage/components/list-sort.css
+++ b/src/list/manage/components/list-sort.css
@@ -5,10 +5,14 @@
 .label {
   color: #4a4a4f;
   font-size: 12px;
+  flex: 0 0 auto;
 }
 
 .select {
+  flex: 0 1 auto;
+  
   color: #0c0c0d;
+  text-overflow: ellipsis;
   appearance: none;
   -moz-appearance: none;
   border: none;

--- a/src/list/manage/components/list-sort.js
+++ b/src/list/manage/components/list-sort.js
@@ -15,6 +15,13 @@ function calcSelectStyle(el) {
 
   return 20 + (el.options[el.selectedIndex].text.length * 8) + "px";
 }
+function calcTitle(el) {
+  if (!el.options) {
+    return "";
+  }
+
+  return el.options[el.selectedIndex].text;
+}
 
 export default class ListSort extends React.Component {
   constructor(props) {
@@ -29,7 +36,10 @@ export default class ListSort extends React.Component {
 
   componentDidMount() {
     // set initial select width
-    this.setState({selectWidth: calcSelectStyle(this.selectEl)});
+    this.setState({
+      selectWidth: calcSelectStyle(this.selectEl),
+      selectTitle: calcTitle(this.selectEl),
+    });
   }
 
   handleChange(evt) {
@@ -38,19 +48,22 @@ export default class ListSort extends React.Component {
     this.props.onChange(value);
 
     // update select width
-    this.setState({selectWidth: calcSelectStyle(evt.target)});
+    this.setState({
+      selectWidth: calcSelectStyle(evt.target),
+      selectTitle: calcTitle(evt.target),
+    });
   }
 
   render() {
     const { disabled } = this.props;
-    const { selectWidth } = this.state;
+    const { selectWidth, selectTitle } = this.state;
     return (
       <React.Fragment>
         <Localized id="sort-by">
           <label className={styles.label}
                  htmlFor="sort-options">sORT bY:</label>
         </Localized>
-        <select id="listSortSelect" value={this.state.value}
+        <select id="listSortSelect" value={this.state.value} title={selectTitle}
                 className={styles.select} style={{width: selectWidth}}
                 onChange={this.handleChange} ref={node => (this.selectEl = node)}
                 disabled={disabled}>

--- a/src/list/manage/containers/add-item.css
+++ b/src/list/manage/containers/add-item.css
@@ -3,5 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
  .add-item {
-     margin: 0 1.5em;
+     flex: 0 0 auto;
+     margin-left: 2em;
+     padding: 0px 2em;
+     min-width: 120px;
  }

--- a/test/unit/list/manage/components/list-sort-test.js
+++ b/test/unit/list/manage/components/list-sort-test.js
@@ -25,6 +25,7 @@ describe("list > manage > components > <ListSort />", () => {
         <ListSort onChange={onChange} value="name" sort="name" disabled={true} />
       );
       expect(wrapper.state().value).to.equal("name");
+      expect(wrapper.state().selectTitle).to.equal("nAMe");
       expect(wrapper.find("select").prop("disabled")).to.be.true;
     });
   });
@@ -52,8 +53,18 @@ describe("list > manage > components > <ListSort />", () => {
       );
     });
 
-    it("updates sort value on select change", () => {
-      wrapper.find("select").simulate("change", {target: {value: "last-used"}});
+    it("updates sort value and title on select change", () => {
+      wrapper.find("select").simulate("change", {
+        target: {
+          value: "last-used",
+          selectedIndex: 1,
+          options: [
+            { value: "name", text: "nAMe" },
+            { value: "last-used", text: "lASt uSEd" },
+            { value: "last-changed", text: "lASt cHANGEd" },
+          ],
+        },
+      });
       expect(onChange).to.have.callCount(1);
       expect(wrapper.state().value).to.equal("last-used");
     });


### PR DESCRIPTION
Fixes #286

Fixes a number of layout and text flow issues with Welsh (`cy`).

## Testing and Review Notes

1, Update the pref `intl.accept_languages` to start with `cy`.
2. Open management interface

## Screenshots or Videos

**In _Welsh_ (`cy`)**
![addon-286 locale-cy](https://user-images.githubusercontent.com/757401/58578753-bb948c00-8206-11e9-8c96-1a2beea97de7.png)

**In _German_ (`de`)**
![image](https://user-images.githubusercontent.com/757401/58579012-61e09180-8207-11e9-8127-fac2d61fe973.png)


**In default _English (US)_ (`en-US`)**
![addon-286 locale-en-US](https://user-images.githubusercontent.com/757401/58578858-00202780-8207-11e9-9f5c-ad88e6d93621.png)


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)