### PR TITLE
Tweaks to Release Publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,7 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             cd ~/project
-            VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
-            echo "Release ${VERSION}"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./addons/lockwise-signed.xpi
+            ./bin/deploy-addon.sh
   build-documentation:
     docker:
       - image: python:3.7

--- a/bin/deploy-addon.sh
+++ b/bin/deploy-addon.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# Deploys a signed extension as a GitHub Release
+
+VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
+echo "Publish ${VERSION}"
+ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -recreate ${VERSION} ./addons/lockwise-signed.xpi


### PR DESCRIPTION
Currently the CircleCI release fails without any error.  This tweaks the publication to better surface errors.