### PR TITLE
Disable Telemetry unless Forced On

### DIFF
--- a/test/unit/background/telemetry-test.js
+++ b/test/unit/background/telemetry-test.js
@@ -31,8 +31,13 @@ describe("background > telemetry", () => {
     spyEmbeddedRecordEvent.restore();
   });
 
-  it("registers for telemetry", () => {
+  it("does not register for telemetry unless forced", () => {
     initializeTelemetry();
+    expect(spyEvents).to.not.have.been.called;
+    expect(spyScalars).to.not.have.been.called;
+  });
+  it("registers for telemetry", () => {
+    initializeTelemetry(true);
     expect(spyEvents).to.have.been.calledWith("lockboxv1", {
       "startup": {
         methods: ["startup"],
@@ -140,7 +145,7 @@ describe("background > telemetry", () => {
 
     let caught = false;
     try {
-      initializeTelemetry();
+      initializeTelemetry(true);
     } catch (e) {
       caught = true;
     }


### PR DESCRIPTION
Connected to #290

As uncovered as part of #290 ([BMO 15555734](https://bugzilla.mozilla.org/show_bug.cgi?id=1555734)), there are some circumstances where registering and recording telemetry events/scalars can cause the browser to crash.

As a mitigation until the root cause is resolved, this PR disables telemetry.

## Testing and Review Notes

1. Install the addon
2. Perform various actions
3. Open `about:telemetry` and observe dynamic events

There should be no events or scalars with the category `lockboxv1`.

## To Do

- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests