### PR TITLE
Hide scrollbars automatically

### DIFF
--- a/src/list/manage/components/item-details.css
+++ b/src/list/manage/components/item-details.css
@@ -8,7 +8,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-flow: column nowrap;
-  overflow: scroll;
+  overflow: auto;
   min-width: 500px;
 }
 


### PR DESCRIPTION
Fixes #268 

## Testing and Review Notes

1. Open the Firefox browser with the profile from prerequisites.
2. Click the "Lockwise" toolbar button.
3. Click the "Open Lockwise" button.
4. Observe the "Lockwise" onboarding page.
5. Resize window to make the scrollbars appear

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [x] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
