### PR TITLE
Fix Firefox max version to 69

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             sudo apt-get install libgtk-3-dev libdbus-glib-1-2
             sudo npm i -g get-firefox
-            get-firefox --branch nightly --platform linux --extract --target ~/
+            get-firefox --branch devedition --platform linux --extract --target ~/
             echo 'export PATH="$HOME/firefox:$PATH"' >> $BASH_ENV
       - run:
           name: Verify Firefox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             sudo apt-get install libgtk-3-dev libdbus-glib-1-2 python-pip
             sudo pip install mozdownload
-            mozdownload --application devedition --platform linux --version latest-beta
+            mozdownload --application devedition --version latest-beta
             tar -C $HOME -xjf devedition-*.tar.bz2
             rm -rf devedition-*.tar.bz2
             echo 'export PATH="$HOME/firefox:$PATH"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,10 @@ jobs:
           name: Install Firefox
           command: |
             sudo apt-get install libgtk-3-dev libdbus-glib-1-2
-            sudo npm i -g get-firefox
-            get-firefox --branch devedition --platform linux --extract --target ~/
+            sudo pip install mozdownload
+            mozdownload --application devedition --platform linux --version latest-beta
+            tar -C $HOME -xjf devedition-*.tar.bz2
+            rm -rf devedition-*.tar.bz2
             echo 'export PATH="$HOME/firefox:$PATH"' >> $BASH_ENV
       - run:
           name: Verify Firefox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Install Firefox
           command: |
-            sudo apt-get install libgtk-3-dev libdbus-glib-1-2
+            sudo apt-get install libgtk-3-dev libdbus-glib-1-2 python-pip
             sudo pip install mozdownload
             mozdownload --application devedition --platform linux --version latest-beta
             tar -C $HOME -xjf devedition-*.tar.bz2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "lockwise",
   "id": "lockbox@mozilla.com",
   "version": "2.2.4-alpha",
-  "description": "Take your passwords everywhere. Note this functionality is built into Firefox 70 and above.",
+  "description": "Take your passwords everywhere. Note this functionality is built into Firefox 70 and above, so this add-on is capped to versions 69 and lower.",
   "engines": {
     "firefox": ">= 67",
     "node": ">=10.15.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "lockwise",
   "id": "lockbox@mozilla.com",
   "version": "2.2.4-alpha",
-  "description": "Take your passwords everywhere.",
+  "description": "Take your passwords everywhere. Note this functionality is built into Firefox 70 and above.",
   "engines": {
     "firefox": ">= 67",
     "node": ">=10.15.0"

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -16,7 +16,7 @@
     "gecko": {
       "id": "{{id}}",
       "strict_min_version": "67.0",
-      "strict_max_version": "69.0",
+      "strict_max_version": "69.*",
       "update_url": "https://lockwise.firefox.com/addon/updates.json"
     }
   },

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -16,6 +16,7 @@
     "gecko": {
       "id": "{{id}}",
       "strict_min_version": "67.0",
+      "strict_max_version": "69.0",
       "update_url": "https://lockwise.firefox.com/addon/updates.json"
     }
   },

--- a/test/integration/driver.js
+++ b/test/integration/driver.js
@@ -23,6 +23,9 @@ const DEFAULT_PREFS = {
 const ENV_BINARY = "LOCKBOX_FIREFOX_BINARY";
 const ENV_HEADLESS = "LOCKBOX_FIREFOX_HEADLESS";
 
+// fixup 'Aurora' (Developer Edition) name ...
+firefox.Channel.AURORA.darwin_ = "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin";
+
 export class WebExtensionDriver {
   constructor(manifest, opts) {
     this.manifest = manifest;


### PR DESCRIPTION
This change, combined with an update to the updates manifest, defers to the built-in functionality in Firefox 70.

See [BMO 1560608](https://bugzilla.mozilla.org/show_bug.cgi?id=1560608)

Connected to #188
Connected to mozilla-lockwise/mozilla-lockwise.github.io#138

## Testing and Review Notes

This add-on should no longer install on Firefox versions 70 or higher.


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)