### PR TITLE
typo

### DIFF
--- a/src/background/README.md
+++ b/src/background/README.md
@@ -38,6 +38,6 @@ Fetches the item with ID `id` from the datastore. Returns the item object in the
 
 Record a telemetry event with method `method`, object `object`, and extra `extra` (value is `null`).
 
-## `telemetry_add"
+## `telemetry_add`
 
 Increment a telemetry counter with `name` by some `value`.


### PR DESCRIPTION
I found a typo in a readme file, here is the fix.
I did not follow the [Contributing guidelines](https://github.com/mozilla-lockwise/lockwise-addon/blob/master/docs/contributing.md) as it is a double quote replaced by a back quote in a readme.md file.